### PR TITLE
dos2unix and ensure newline at EOF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,19 +6,18 @@ BINDIR=$(PREFIX)/bin
 
 all: zpaqfranz
 
-zpaqfranz: 
+zpaqfranz:
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) zpaqfranz.cpp -o $@ -pthread
 
 install: zpaqfranz
 	install -m 0755 -d $(DESTDIR)$(BINDIR)
 	install -m 0755 zpaqfranz $(DESTDIR)$(BINDIR)
-	
+
 clean:
 	rm -f zpaqfranz
 
 check: zpaqfranz
-	rm archive.zpaq 
+	rm archive.zpaq
 	./zpaqfranz a archive.zpaq zpaqfranz.cpp
 	./zpaqfranz t archive.zpaq -verify
-	rm archive.zpaq 
-	
+	rm archive.zpaq


### PR DESCRIPTION
spotted while trying to build it on OpenBSD: make(1) fails with files that use CRLF.  While here I'm also removing some trailing whitespaces and ensuring a newline at EOF.