### PR TITLE
fix build with -DNOJIT

### DIFF
--- a/zpaqfranz.cpp
+++ b/zpaqfranz.cpp
@@ -272,9 +272,7 @@ check: zpaqfranz
 #include <cstddef>
 
 #ifdef unix
-	#ifndef NOJIT
-		#include <sys/mman.h>
-	#endif
+	#include <sys/mman.h>
 
 	#define PTHREAD 1
 	#include <termios.h>


### PR DESCRIPTION
mmap(2) is called also in places not guarded by -DNOJIT.  I'm not familiar with the codebase, but this allows to build it with -DNOJIT and from some brief testing it seems to be still working :)