### PR TITLE
signal was not declared in this scope

### DIFF
--- a/zpaqfranz.cpp
+++ b/zpaqfranz.cpp
@@ -1799,6 +1799,7 @@ SHA-256: FCCE109C8360963EB18975B94BDBE434BE1A49D3F53BDD768A99093B3EB838D2 [     
 	#include <math.h>
 	#include <memory>
 	#include <pthread.h>
+	#include <signal.h>
 	#include <stdarg.h>
 	#include <stdexcept>
 	#include <stdio.h>


### PR DESCRIPTION
Trying to compile it in Linux got this error:
> error: ‘signal’ was not declared in this scope
Added signal header include in the unix section.


Error in full:
```
g++ -std=c++11 -Wall -O2 -c -o zpaqfranz.o zpaqfranz.cpp
zpaqfranz.cpp: In function ‘int main(int, const char**)’:
zpaqfranz.cpp:54352:10: error: ‘SIGINT’ was not declared in this scope
  signal (SIGINT,my_handler); // the control-C handler
          ^~~~~~
zpaqfranz.cpp:54352:27: error: ‘signal’ was not declared in this scope
  signal (SIGINT,my_handler); // the control-C handler
                           ^
make: *** [zpaqfranz.o] Error 1
```
When [looked for error](https://duckduckgo.com/?q=error%3A+%27SIGINT%27+was+not+declared+in+this+scope&ia=qa) I got this this answer: [You haven't included signal.h. ](http://stackoverflow.com/questions/52294232/ddg#52294447). Therefore added `#include <signal.h>`.


