### PR TITLE
use PREFIX in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ### generic Makefile. Look at BINDIR for the prefix (/usr/bin instead of /usr/local/bin)
-### Generally, but not always, /usr/local/bin is for "BSD-style" systems, while /usr/bin is for older Linux systems  
-### In reality, each platform has its own custom:cannot know "a priori"  
+### Generally, but not always, /usr/local/bin is for "BSD-style" systems, while /usr/bin is for older Linux systems
+### In reality, each platform has its own custom:cannot know "a priori"
 
 ### Usually a straight
 ### make install clean
@@ -12,17 +12,18 @@ RM?=            rm
 PROG=           zpaqfranz
 CFLAGS+=        -O3 -Dunix
 LDADD=          -pthread -lstdc++ -lm
-BINDIR=         /usr/local/bin
+PREFIX=         /usr/local
+BINDIR=         ${PREFIX}/bin
 BSD_INSTALL_PROGRAM?=   install -m 0555
 
 all:    build
 
-build:  ${PROG}
+build: ${PROG}
 
-install:        ${PROG}
+install: ${PROG}
 	${BSD_INSTALL_PROGRAM} ${PROG} ${DESTDIR}${BINDIR}
 
-${PROG}:        ${OBJECTS}
-	${CC}  ${CFLAGS} zpaqfranz.cpp -o ${PROG} ${LDADD}
+${PROG}: ${OBJECTS}
+	${CC} ${CFLAGS} zpaqfranz.cpp -o ${PROG} ${LDADD}
 clean:
 	${RM} -f ${PROG}


### PR DESCRIPTION
So prefix can be controlled during install process:
```
$ make -n install PREFIX=/usr DESTDIR=/tmp/zf
install -m 0555 zpaqfranz /tmp/zf/usr/bin
```