### PR TITLE
Use more common build variables, fix build rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,26 @@
 ### make install clean
 ### is good enough
 
-CC?=            cc
+CXX?=           cc
 INSTALL?=       install
 RM?=            rm
 PROG=           zpaqfranz
-CFLAGS+=        -O3 -Dunix
-LDADD=          -pthread -lstdc++ -lm
+SOURCE=         zpaqfranz.cpp
+CPPFLAGS+=	-Dunix
+CXXFLAGS+=	-O3 -pthread
+LDLIBS=		-lm
 BINDIR=         /usr/local/bin
-BSD_INSTALL_PROGRAM?=   install -m 0555
+BSD_INSTALL_PROGRAM?=   ${INSTALL} -m 0755
 
 all:    build
 
 build:  ${PROG}
 
 install:        ${PROG}
-	${BSD_INSTALL_PROGRAM} ${PROG} ${DESTDIR}${BINDIR}
+	${BSD_INSTALL_PROGRAM} -d ${DESTDIR}${BINDIR}
+	${BSD_INSTALL_PROGRAM} $^ ${DESTDIR}${BINDIR}
 
-${PROG}:        ${OBJECTS}
-	${CC}  ${CFLAGS} zpaqfranz.cpp -o ${PROG} ${LDADD}
+${PROG}:        ${SOURCE}
+	${CXX} ${CPPFLAGS} ${CXXFLAGS} ${LDFLAGS} $^ ${LDLIBS} -o $@
 clean:
 	${RM} -f ${PROG}


### PR DESCRIPTION
See
https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html for reference (I know that manual is GNU-specific, but most of this is not GNU-specific).

Since the code is C++, appropriate compiler and flags variables are CXX and CXXFLAGS. Pre-processor directives go in CPPFLAGS. Libraries are specified in LDLIBS; the standard C++ library is included automatically when appropriate and does not need to be specified.

The target directory should be created (for use with non-default DESTDIR). To allow this, specify 0755 instead of 0555.

Automatic variables are used where appropriate.