### PR TITLE
Correct zpaq.AES from libtomcrypt license name

### DIFF
--- a/zpaqfranz.cpp
+++ b/zpaqfranz.cpp
@@ -269,7 +269,7 @@ Credits and copyrights and licenses and links and internal bookmarks
 	I grant anyone the right to use this software for any purpose,
 	without any conditions, unless such conditions are required by law.
 
- 1 [Public domain]                zpaq.AES from libtomcrypt by Tom St Denis
+ 1 [The Unlicense]                zpaq.AES from libtomcrypt by Tom St Denis
  /// LICENSE_START.1
  /// LICENSE_END.1
 	The LibTom license


### PR DESCRIPTION
The license is known under "The Unlicense" name. See <https://spdx.org/licenses/Unlicense.html> and line 465 in zpaqfranz.cpp where you already use that license for "wyhash (experimental) WangYi" code.