### PR TITLE
Docker integration for official releases

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,89 @@
+name: Build container image
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    if: github.event.release.prerelease == false
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Prepare docker build context
+        run: cp zpaqfranz.cpp docker/zpaqfranz.cpp
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image name
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: docker
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          pull: true
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+          build-args: |
+            ZPAQ_REPOSITORY=${{ github.repository }}
+            ZPAQ_VERSION=${{ github.event.release.tag_name }}
+
+      - name: Tag as latest
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          image="${REGISTRY}/${IMAGE_NAME}"
+          tag="${{ github.event.release.tag_name }}"
+          if ! latest_json="$(
+            curl -fsSL \
+              --retry 3 \
+              --retry-delay 2 \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest"
+          )"; then
+            echo "::error::Failed to query GitHub API for latest release"
+            exit 1
+          fi
+
+          if ! latest="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("tag_name",""))' <<<"$latest_json")"; then
+            echo "::error::Failed to parse latest release JSON"
+            exit 1
+          fi
+          if [ -z "$latest" ]; then
+            echo "::error::GitHub API returned no tag_name for latest release"
+            exit 1
+          fi
+
+          if [ "$latest" != "$tag" ]; then
+            echo "::notice::Skipping :latest tag (GitHub latest is ${latest}, event tag is ${tag})."
+            exit 0
+          fi
+
+          echo "Applying :latest tag to ${tag}"
+          docker buildx imagetools create --tag "${image}:latest" "${image}:${tag}"

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,4 @@
+**
+!.dockerignore
+!Dockerfile
+!zpaqfranz.cpp

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+zpaqfranz.cpp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1.7
+ARG ZPAQ_REPOSITORY=fcorbelli/zpaqfranz
+
+FROM ubuntu:24.04 AS build
+
+ARG TARGETARCH
+ARG ZPAQ_VERSION
+WORKDIR /src
+
+RUN apt-get update \
+    && build_essential_version="$(apt-cache policy build-essential | awk '/Candidate:/ {print $2}')" \
+    && ca_certificates_version="$(apt-cache policy ca-certificates | awk '/Candidate:/ {print $2}')" \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      build-essential="${build_essential_version}" \
+      ca-certificates="${ca_certificates_version}" \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY zpaqfranz.cpp /src/zpaqfranz.cpp
+
+RUN set -eux; \
+    resolved_arch="${TARGETARCH:-}"; \
+    if [ -z "$resolved_arch" ]; then \
+      case "$(uname -m)" in \
+        x86_64) resolved_arch="amd64" ;; \
+        aarch64 | arm64) resolved_arch="arm64" ;; \
+      esac; \
+    fi; \
+    extra_defines=""; \
+    case "$resolved_arch" in \
+      amd64) extra_defines="-DHWSHA2" ;; \
+      *) extra_defines="-DNOJIT" ;; \
+    esac; \
+    g++ -O3 -pthread -Dunix $extra_defines zpaqfranz.cpp -o zpaqfranz -lm \
+    && strip zpaqfranz
+
+FROM ubuntu:24.04
+
+ARG ZPAQ_VERSION
+ARG ZPAQ_REPOSITORY
+
+RUN apt-get update \
+    && ca_certificates_version="$(apt-cache policy ca-certificates | awk '/Candidate:/ {print $2}')" \
+    && libstdcpp6_version="$(apt-cache policy libstdc++6 | awk '/Candidate:/ {print $2}')" \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      ca-certificates="${ca_certificates_version}" \
+      libstdc++6="${libstdcpp6_version}" \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -r zpaq && useradd -r -g zpaq -d /var/lib/zpaq -s /usr/sbin/nologin zpaq \
+    && mkdir -p /var/lib/zpaq /data \
+    && chown zpaq:zpaq /var/lib/zpaq /data
+
+COPY --from=build /src/zpaqfranz /usr/local/bin/zpaqfranz
+
+RUN /usr/local/bin/zpaqfranz version
+
+LABEL org.opencontainers.image.title="zpaqfranz" \
+      org.opencontainers.image.description="Minimal multi-arch zpaqfranz packaged on Ubuntu LTS" \
+      org.opencontainers.image.source="https://github.com/${ZPAQ_REPOSITORY}" \
+      org.opencontainers.image.version="${ZPAQ_VERSION}"
+
+WORKDIR /data
+USER zpaq
+
+ENTRYPOINT ["/usr/local/bin/zpaqfranz"]
+CMD ["-h"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,56 @@
+<!-- markdownlint-disable MD041 -->
+
+A slim, multi-architecture Docker image that compiles `zpaqfranz`
+from source on Ubuntu (glibc) and publishes it to GHCR.
+
+Quick start
+
+```bash
+docker pull ghcr.io/fcorbelli/zpaqfranz:latest
+
+docker run --rm ghcr.io/fcorbelli/zpaqfranz:latest version
+
+docker run --rm \
+  -v "$PWD:/data" \
+  ghcr.io/fcorbelli/zpaqfranz:latest \
+  a backup.zpaq .
+```
+
+The container entrypoint is `zpaqfranz`, so any additional arguments
+are passed straight through to the tool.
+The default working directory is `/data`, and the image runs as a
+non-root user.
+
+If you bind-mount a host directory and get permission errors, run the
+container as your user:
+
+```bash
+docker run --rm \
+  -u "$(id -u):$(id -g)" \
+  -v "$PWD:/data" \
+  ghcr.io/fcorbelli/zpaqfranz:latest \
+  a backup.zpaq .
+```
+
+Local build
+
+The Docker build context is `docker/` (kept small on purpose), so you
+need to stage `zpaqfranz.cpp` into it:
+
+```bash
+cp zpaqfranz.cpp docker/zpaqfranz.cpp
+docker build -t zpaqfranz:local -f docker/Dockerfile docker
+```
+
+Tags and architectures
+
+- `ghcr.io/fcorbelli/zpaqfranz:latest` for `linux/amd64` and
+  `linux/arm64` (most recent build).
+- `ghcr.io/fcorbelli/zpaqfranz:<version>` for `linux/amd64` and
+  `linux/arm64` (specific zpaqfranz tag, for example `64.4`).
+
+How it stays up to date
+
+- Publishing a new GitHub Release triggers the container build
+  workflow, which builds multi-arch images with Docker Buildx and
+  pushes them to GHCR.


### PR DESCRIPTION
Hi Franco,

I just finished development/testing for Docker integration and opened this PR for your review.

Current behavior:
- Builds and publishes Docker images only on official published releases.
- No builds for prereleases.
- Older/historical releases are not backfilled right now.

Build time is around 15-20 minutes, mostly because arm64 is built via emulation on GitHub runners.

I have not updated the main README yet. I can send a follow-up PR for docs once the package/release flow is finalized.

Happy to adjust anything if you want changes.